### PR TITLE
Make ui_tables look like they belong

### DIFF
--- a/css/webmin.css
+++ b/css/webmin.css
@@ -266,3 +266,24 @@ input[type='checkbox'] + label > i{
 	color: #eee;
 	text-decoration: none;
 }
+
+/*Added by piersg to improve the look of ui tables*/
+.ui_table td {
+ padding-bottom: 0.25em;
+ padding-left: 0.5em;
+ padding-right: 0.5em;
+ padding-top: .25em;
+}
+.ui_table { 
+ border-width: 0px;
+ border-color:#fff;
+}
+.ui_table_head {background-color: #eee}
+.ui_table_body {background-color: #f4f4f4}
+.ui_label{
+ text-align: right;
+ vertical-align: middle;
+}
+.ui_table_row {border-bottom: 1px solid #ddd;}
+/*makes non-form text line up better w/ form elements:*/
+.ui_value {vertical-align: middle}

--- a/css/webmin.css
+++ b/css/webmin.css
@@ -269,21 +269,29 @@ input[type='checkbox'] + label > i{
 
 /*Added by piersg to improve the look of ui tables*/
 .ui_table td {
- padding-bottom: 0.25em;
- padding-left: 0.5em;
- padding-right: 0.5em;
- padding-top: .25em;
+	padding-bottom: 0.25em;
+	padding-left: 0.5em;
+	padding-right: 0.5em;
+	padding-top: .25em;
 }
 .ui_table { 
- border-width: 0px;
- border-color:#fff;
+	border-width: 0px;
+	border-color:#fff;
 }
-.ui_table_head {background-color: #eee}
-.ui_table_body {background-color: #f4f4f4}
+.ui_table_head {
+	background-color: #eee;
+}
+.ui_table_body {
+	background-color: #f4f4f4;
+}
 .ui_label{
  text-align: right;
  vertical-align: middle;
 }
-.ui_table_row {border-bottom: 1px solid #ddd;}
+.ui_table_row {
+	border-bottom: 1px solid #ddd;
+}
 /*makes non-form text line up better w/ form elements:*/
-.ui_value {vertical-align: middle}
+.ui_value {
+	vertical-align: middle;
+}


### PR DESCRIPTION
I humbly submit a few lines of css to make `ui_table` sections of webmin look a little more like they fit in (e.g. the "Others/Upload and Download" page shows the difference before and after pretty well. It's not perfect, but it goes a long way to make the bits of Webmin I use a lot look as nice as the rest of your very pretty (and useable) theme.

I did two commits because I don't use Github very often, but I _think_ it's coalesced them all into one here.

Grazie!
