### PR TITLE
Fix iOS (WebKit touch?) scrolling

### DIFF
--- a/css/webmin.css
+++ b/css/webmin.css
@@ -191,7 +191,8 @@ body {
 	-webkit-transition: all 0.4s ease;
 	height: calc(100% - 51px);
 	margin-top: -20px;
-	overflow: hidden;
+        -webkit-overflow-scrolling: touch;   
+	overflow: scroll;
 }
 .iframe-container.iframe-close {
 	margin-left: 60px;


### PR DESCRIPTION
TL;DR: overflow scrolling doesn't work on my iPad. This fixes it (but I don't know what it breaks)

... but it does work on Android phones and iPhones. Was broken on Safari and Chrome (iOS 7)

Hypothesis:
This is an iframe overflow scroll issue, it's not seen on smaller screens as the navbar gets collapsed (so no iframe?). WebKit appears to not want to let overflowed iframes scroll on touch devices by default. See refs at end for more info.

The changes made here make scrolling work on said iPad and do not appear to break anything on my phones or desktop, but this is hardly my area of expertise so I would call these changes very much "use at own risk, and TEST". Changing 'overflow' from 'hidden' to 'scroll' is pretty much the opposite, so if it was set to 'hidden' to enable some functionality, I just broke it!

I also haven't tested the change in iOS 8, but the last article (in my refs, below) indicates, possibly, that Apple have changed the way the property behaves.

Lastly I wonder if it might be a better long-term fix to find a way of doing the side navbar without introducing iframes - we might be able to avoid some vendor CSS.

I looked for "bootstrap iOS scroll issues" and found the following which pointed me towards the overflow scroll fix:
https://github.com/twbs/bootstrap/issues/3361
https://github.com/twbs/bootstrap/issues/14839
